### PR TITLE
fix(copy): strip inline code annotations and diff markers from copied code — fixes #2222

### DIFF
--- a/src/components/code-example.tsx
+++ b/src/components/code-example.tsx
@@ -190,12 +190,30 @@ export function RawHighlightedCode({
   return <div className={className} dangerouslySetInnerHTML={{ __html: code }} />;
 }
 
-function cleanCodeForCopy(code:string) {
+function cleanCodeForCopy(code: string) {
   return code
-    .split('\n')
-    .filter(line => !line.includes('[!code highlight'))
-    .join('\n');
+    .split("\n")
+    .map(line => {
+      
+      line = line.replace(/\s*\/\/\s*\[!code.*?\]/g, ""); 
+      line = line.replace(/\s*<!--\s*\[!code.*?\]-->/g, ""); 
+      line = line.replace(/\s*#\s*\[!code.*?\]/g, ""); 
+
+      
+      if (/^[+-]/.test(line.trim())) {
+        line = line.trim().slice(1);
+      }
+
+     
+      if (line.trim() === "…") return "";
+
+      return line;
+    })
+    .filter(line => line.trim() !== "")
+    .join("\n")
+    .trim();
 }
+
 
 function CodeExampleFilename({ filename, code }: { filename: string; code?: string }) {
   return (


### PR DESCRIPTION
This PR improves the "Copy to Clipboard" functionality for code snippets in the documentation.

### Changes:
- Removes all Shiki inline annotations such as `[!code highlight]`, `[!code diff]`, etc.
- Ensures copied code is clean, readable, and production-ready.
- Specifically addresses the feedback from @rozsazoltan and @philipp-spiess regarding comments and diff views being copied unnecessarily.

### Related Issue:
Fixes #2222

Let me know if any further refinements are needed!
